### PR TITLE
Updated prototypes with a transformation area postcode

### DIFF
--- a/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-behaviour.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-behaviour.html
@@ -93,7 +93,7 @@
           Postcode
         </dt>
         <dd class="govuk-summary-list__value">
-          XYXX XYX
+          N511 2YH
         </dd>
         <dd class="govuk-summary-list__actions">
          <!--  <a class="govuk-link" href="#">

--- a/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-interpreter-removed.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-interpreter-removed.html
@@ -104,7 +104,7 @@
           Postcode
         </dt>
         <dd class="govuk-summary-list__value">
-          XYXX XYX
+          N511 2YH
         </dd>
         <dd class="govuk-summary-list__actions">
          <!--  <a class="govuk-link" href="#">

--- a/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-interpreter.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail-updated-interpreter.html
@@ -104,7 +104,7 @@
           Postcode
         </dt>
         <dd class="govuk-summary-list__value">
-          XYXX XYX
+          N511 2YH
         </dd>
         <dd class="govuk-summary-list__actions">
          <!--  <a class="govuk-link" href="#">

--- a/app/views/richer-claimant-info/v12/pip-claimant-detail-updated.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail-updated.html
@@ -91,7 +91,7 @@
           Postcode
         </dt>
         <dd class="govuk-summary-list__value">
-          XYXX XXX
+          N511 2YH
         </dd>
         <dd class="govuk-summary-list__actions">
 

--- a/app/views/richer-claimant-info/v12/pip-claimant-detail.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail.html
@@ -78,7 +78,7 @@
           Postcode
         </dt>
         <dd class="govuk-summary-list__value">
-          XYXX XYX
+          N511 2YH
         </dd>
         <dd class="govuk-summary-list__actions">
          <!--  <a class="govuk-link" href="#">

--- a/app/views/richer-claimant-info/v7-1/change-singular/gp-address-lookup.html
+++ b/app/views/richer-claimant-info/v7-1/change-singular/gp-address-lookup.html
@@ -30,7 +30,7 @@ Enter claimant address - Health Assessment Service
       <div class="govuk-hint">
         For example, AA3 1AB
       </div>
-      <input class="govuk-input govuk-!-width-two-thirds" id="address-town" name="address-town" type="text" autocomplete="address-level2" value="XX11 1XX" >
+      <input class="govuk-input govuk-!-width-two-thirds" id="address-town" name="address-town" type="text" autocomplete="address-level2" value="N511 2YH" >
     </div>
   
     <div class="govuk-form-group">

--- a/app/views/richer-claimant-info/v7-1/change-singular/gp-find-address-confirm.html
+++ b/app/views/richer-claimant-info/v7-1/change-singular/gp-find-address-confirm.html
@@ -21,7 +21,7 @@ Confirm claimant address - Health Assessment Service
     Confirm address
       </h1>
 
-      <p>1 address found for <b>XX11 1XX</b> and <b>Medical group</b>. <a href="gp-address-lookup">Search again</a></p>
+      <p>1 address found for <b>N511 2YH</b> and <b>Medical group</b>. <a href="gp-address-lookup">Search again</a></p>
            
       <div class="govuk-inset-text">
         Medical group
@@ -29,7 +29,7 @@ Confirm claimant address - Health Assessment Service
 
 
         
-      <br>St Michaels way<br>  Test City <br>XX11 1XX</div>
+      <br>St Michaels way<br>  Test City <br>N511 2YH</div>
 
   
   

--- a/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
@@ -408,7 +408,7 @@ PIP
               Address
             </dt>
             <dd class="govuk-summary-list__value">
-             Medical group<br>St Michaels way<br>Test City<br>XX11 1XX
+             Medical group<br>St Michaels way<br>Test City<br>N311 6YH
             </dd>
     
           </div>
@@ -497,7 +497,7 @@ PIP
                   Address
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  1 Test Hospital<br>Test City<br>XX11 1XX
+                  1 Test Hospital<br>Test City<br>N311 6TR
                 </dd>
        
               </div>
@@ -585,7 +585,7 @@ PIP
                 Address
               </dt>
               <dd class="govuk-summary-list__value">
-                1 Hospital Street<br/>Test City<br/>XX11 1XX
+                1 Hospital Street<br/>Test City<br/>N311 5TD
               </dd>
       
             </div>
@@ -674,7 +674,7 @@ PIP
                   Address
                 </dt>
                 <dd class="govuk-summary-list__value">
-                  20 Surgery Lane<br>Test Town<br>XX21 1XX
+                  20 Surgery Lane<br>Test Town<br>N511 2YH
                 </dd>
        
               </div>
@@ -760,7 +760,7 @@ PIP
                     Address
                   </dt>
                   <dd class="govuk-summary-list__value">
-                    103 Salt Road <br>Test Town<br>XX13 2XX
+                    103 Salt Road <br>Test Town<br>N511 2YH
                   </dd>
          
                 </div>
@@ -851,7 +851,7 @@ PIP
                     Address
                   </dt>
                   <dd class="govuk-summary-list__value">
-                    99 Practice Road <br>Test Town<br>XX13 2XX
+                    99 Practice Road <br>Test Town<br>N311 7HH
                   </dd>
          
                 </div>

--- a/app/views/richer-claimant-info/v7-1/pip-case-details.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details.html
@@ -340,7 +340,7 @@ PIP
           Address
         </dt>
         <dd class="govuk-summary-list__value">
-         Medical group<br>St Michaels way<br>Test City<br>XX11 1XX
+         Medical group<br>St Michaels way<br>Test City<br>N311 6YH
         </dd>
 
       </div>
@@ -429,7 +429,7 @@ PIP
               Address
             </dt>
             <dd class="govuk-summary-list__value">
-              1 Test Hospital<br>Test City<br>XX11 1XX
+              1 Test Hospital<br>Test City<br>N311 6TR
             </dd>
 
           </div>
@@ -517,7 +517,7 @@ PIP
             Address
           </dt>
           <dd class="govuk-summary-list__value">
-            1 Hospital Street<br/>Test City<br/>XX11 1XX
+            1 Hospital Street<br/>Test City<br/>N311 5TD
           </dd>
 
         </div>
@@ -603,7 +603,7 @@ PIP
               Address
             </dt>
             <dd class="govuk-summary-list__value">
-              20 Surgery Lane<br>Test Town<br>XX21 1XX
+              20 Surgery Lane<br>Test Town<br>N511 2YH
             </dd>
 
           </div>
@@ -688,7 +688,7 @@ PIP
                 Address
               </dt>
               <dd class="govuk-summary-list__value">
-                103 Salt Road <br>Test Town<br>XX13 2XX
+                103 Salt Road <br>Test Town<br>N211 7YH
               </dd>
 
             </div>

--- a/app/views/richer-claimant-info/v7-1/pip-claimant-detail-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-claimant-detail-updated.html
@@ -178,7 +178,7 @@ Sam Doe
          Residential address
         </dt>
         <dd class="govuk-summary-list__value">
-          1 Test Street<br/>Test City<br/>XX11 1XX
+          1 Test Street<br/>Test City<br/>N311 8GH
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/personal-find-address">
@@ -192,7 +192,7 @@ Sam Doe
         </dt>
         <dd class="govuk-summary-list__value">
 
-            23 Other Avenue<br>Other City<br>XX22 2XX
+            23 Other Avenue<br>Other City<br>N611 2ER
 
         </dd>
         <dd class="govuk-summary-list__actions">
@@ -402,7 +402,7 @@ Sam Doe
              Address
            </dt>
            <dd class="govuk-summary-list__value">
-           10 Test Street<br>Test City<br>XX12 1XX
+           10 Test Street<br>Test City<br>N411 5ER
            </dd>
    
          </div>

--- a/app/views/richer-claimant-info/v7-1/pip-claimant-detail.html
+++ b/app/views/richer-claimant-info/v7-1/pip-claimant-detail.html
@@ -157,7 +157,7 @@ Sam Doe
          Residential address
         </dt>
         <dd class="govuk-summary-list__value">
-          1 Test Street<br/>Test City<br/>XX11 1XX
+          1 Test Street<br/>Test City<br/>N311 8GH
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/personal-find-address">
@@ -171,7 +171,7 @@ Sam Doe
         </dt>
         <dd class="govuk-summary-list__value">
 
-            23 Other Avenue<br>Other City<br>XX22 2XX
+            23 Other Avenue<br>Other City<br>N611 2ER
 
         </dd>
         <dd class="govuk-summary-list__actions">
@@ -386,7 +386,7 @@ Sam Doe
             Address
           </dt>
           <dd class="govuk-summary-list__value">
-            10 Test Street<br>Test City<br>XX12 1XX
+            10 Test Street<br>Test City<br>N411 5ER
           </dd>
   
         </div>


### PR DESCRIPTION
Updated v7.1 and v12 prototypes with a transformation area postcode instead of postcodes that are'XXX XXXX'