### PR TITLE
Reordered fields and changed terminology on referral details page

### DIFF
--- a/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
@@ -131,20 +131,6 @@
   
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Consent to contact GP
-        </dt>
-        <dd class="govuk-summary-list__value">
-          Yes
-        </dd>
-        <dd class="govuk-summary-list__actions">
-          <a class="govuk-link" href="change-singular/consent-gp">
-            Change<span class="govuk-visually-hidden"> Contact GP</span>
-          </a>
-        </dd>
-      </div>
-
-      <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">
           Special rules end of life
         </dt>
         <dd class="govuk-summary-list__value">
@@ -156,6 +142,22 @@
           </a>
         </dd>
       </div>
+      
+      
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Consent more medical evidence
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Yes
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/consent-gp">
+            Change<span class="govuk-visually-hidden"> Contact GP</span>
+          </a>
+        </dd>
+      </div>
+
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
@@ -173,7 +175,7 @@
 
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Unacceptable behaviour
+          Safety measures
         </dt>
         <dd class="govuk-summary-list__value">
           Yes  <!-- <ul class="govuk-list govuk-list--bullet">
@@ -256,7 +258,7 @@ PIP
 
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
-        Case type
+        Referral type
       </dt>
       <dd class="govuk-summary-list__value">
         New referral

--- a/app/views/richer-claimant-info/v7-1/pip-case-details.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details.html
@@ -116,6 +116,21 @@
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">
 
 
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">
+          Special rules end of life
+        </dt>
+        <dd class="govuk-summary-list__value">
+          Yes
+        </dd>
+        <dd class="govuk-summary-list__actions">
+          <a class="govuk-link" href="change-singular/important-end-of-life">
+            Change<span class="govuk-visually-hidden"> Special rules</span>
+          </a>
+        </dd>
+      </div>
+
+
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
             Consent for medical evidence
@@ -130,19 +145,7 @@
           </dd>
         </div>
 
-        <div class="govuk-summary-list__row">
-          <dt class="govuk-summary-list__key">
-            Special rules end of life
-          </dt>
-          <dd class="govuk-summary-list__value">
-            Yes
-          </dd>
-          <dd class="govuk-summary-list__actions">
-            <a class="govuk-link" href="change-singular/important-end-of-life">
-              Change<span class="govuk-visually-hidden"> Special rules</span>
-            </a>
-          </dd>
-        </div>
+
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
@@ -160,7 +163,7 @@
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Unacceptable behaviour
+            Safety measures
           </dt>
           <dd class="govuk-summary-list__value">
 
@@ -245,7 +248,7 @@ PIP
 
         <div class="govuk-summary-list__row">
           <dt class="govuk-summary-list__key">
-            Case type
+            Referral type
           </dt>
           <dd class="govuk-summary-list__value">
             New referral


### PR DESCRIPTION
- Reordered fields on the page to reflect what we have in live (in v7.1)

- Terminology such as “Unacceptable behaviour' have now been changed to ‘Safety measures’, and ‘Case type’ have been changed to ‘Referral type’ (in v7.1)