### PR TITLE
Removed H1 on referral details page

### DIFF
--- a/app/views/richer-claimant-info/v11/pip-case-details.html
+++ b/app/views/richer-claimant-info/v11/pip-case-details.html
@@ -56,7 +56,9 @@
 
 
 
-    <h1 class="govuk-heading-l">Referral details</h1>
+    <!--<h1 class="govuk-heading-l">Referral details</h1>-->
+
+    <h2 class="govuk-heading-m">Referral details</h2>
 
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/app/views/richer-claimant-info/v11/pip-claimant-detail.html
+++ b/app/views/richer-claimant-info/v11/pip-claimant-detail.html
@@ -53,7 +53,7 @@
 
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-<h1 class="govuk-heading-l" id="personal">Claimant details</h2>
+<!-- <h1 class="govuk-heading-l" id="personal">Claimant details</h2> -->
 
  <h2 class="govuk-heading-m" id="personal">Personal details</h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/app/views/richer-claimant-info/v12/pip-case-details.html
+++ b/app/views/richer-claimant-info/v12/pip-case-details.html
@@ -61,7 +61,7 @@
 
 
 
-    <h1 class="govuk-heading-l">Referral details</h1>
+    <h2 class="govuk-heading-m">Referral details</h2>
 
 
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">

--- a/app/views/richer-claimant-info/v12/pip-claimant-detail.html
+++ b/app/views/richer-claimant-info/v12/pip-claimant-detail.html
@@ -53,7 +53,7 @@
 
   <div class="govuk-grid-column-two-thirds-from-desktop">
 
-<h1 class="govuk-heading-l" id="personal">Claimant details</h2>
+ <!-- <h1 class="govuk-heading-l" id="personal">Claimant details</h1>-->
 
  <h2 class="govuk-heading-m" id="personal">Personal details</h2>
     <dl class="govuk-summary-list govuk-!-margin-bottom-9">


### PR DESCRIPTION
Removed H1 from referral details page in v11 and v12 of prototype to reflect live