### PR TITLE
Changed text for 'Consent for medical evidence' field

### DIFF
--- a/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
+++ b/app/views/richer-claimant-info/v7-1/pip-case-details-updated.html
@@ -146,7 +146,7 @@
       
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-          Consent more medical evidence
+          Consent for medical evidence
         </dt>
         <dd class="govuk-summary-list__value">
           Yes


### PR DESCRIPTION
v7.1 referral details page with success banner - Changed text in field from 'Consent more medical evidence' to
 'Consent for medical evidence'