### PR TITLE
Displaying SREL selection on PIP case details updated page

### DIFF
--- a/app/views/pip-has-integration/pip-has-integration.html
+++ b/app/views/pip-has-integration/pip-has-integration.html
@@ -26,10 +26,12 @@
 
           <li><a href="https://dwpdigital.atlassian.net/browse/HTC-2515" target="_blank">See Jira task 2515 for more details (opens in new tab)</a></li>
           <li><a href="https://app.mural.co/t/dwpdigital7412/m/dwpdigital7412/1709571288340/183c6db5ce87a53ffccf33fe4591c9ecc108e4e2?wid=124-1715183042765" target="_blank">See Mural board for more details (opens in new tab)</a></li>
-          <li>Add</li>
-          <li>Add</li>
-         
-      </ul>
+          <li>This prototype reflects the referral and claimant data that have been requested from PIP, and will be displayed in HAS for PIP New Service thin slice integration</li>
+          <li>Referral and claimant data will be pulled from PIP into HAS via an API. The majority of data fields will not be editable, as HAS will always retrieve the most up to date data from PIP.</li>
+          <li>However, there will be certain 'change of circumstances' fields which PIP cannot supply and is crucial to HAS, such as 'Safety measures' and 'Interpreter' information. So these fields must remain editable.</li>
+          <li>The intention is, for Septemebr 2024 we display in HAS the most crucial and highest priority data that PIP can supply to us. But overtime we work with PIP to incrementally display more referral and claimant data in HAS. </li>
+      
+        </ul>
 
       <a href="/pip-has-integration/v1/pip-case-details.html" role="button" draggable="false" class="govuk-button govuk-button--start govuk-!-margin-top-2 govuk-!-margin-bottom-8"  data-module="govuk-button">
          Start

--- a/app/views/pip-has-integration/v1/change-singular/important-end-of-life.html
+++ b/app/views/pip-has-integration/v1/change-singular/important-end-of-life.html
@@ -23,18 +23,19 @@ Special rules case - Health Assesssment Service
 
    <div class="govuk-form-group">
      <fieldset class="govuk-fieldset" role="group" aria-describedby="claimant-names">
-      <form action="/richer-claimant-info/v7-1/pip-case-details-updated.html" method="post" novalidate=""></form>
-
+      
+      <!-- <form action="/richer-claimant-info/v7-1/pip-case-details-updated.html" method="post" novalidate=""></form> -->
+      <form class="form" action="../pip-case-details-updated" method="post">
 
           <div class="govuk-radios" data-module="govuk-radios">
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="important-special-rules-yes" name="important-special-rules" type="radio" value="yes" checked>
+              <input class="govuk-radios__input" id="important-special-rules-yes" name="important-special-rules" type="radio" value="Yes" checked>
               <label class="govuk-label govuk-radios__label" for="important-special-rules-yes" >
                 Yes
               </label>
             </div>
             <div class="govuk-radios__item">
-              <input class="govuk-radios__input" id="important-special-rules-no" name="important-special-rules" type="radio" value="no">
+              <input class="govuk-radios__input" id="important-special-rules-no" name="important-special-rules" type="radio" value="No">
               <label class="govuk-label govuk-radios__label" for="important-special-rules-no">
                 No
               </label>
@@ -48,10 +49,12 @@ Special rules case - Health Assesssment Service
 
 
 
-      <a href="../pip-case-details-updated"> <button class="govuk-button" data-module="govuk-button">
+      <!-- <a href="../pip-case-details-updated">  -->
+        <button class="govuk-button" data-module="govuk-button">
         Continue
         </button>
-      </a>
+        </form>
+      <!-- </a> -->
 
     </div>
   </div>

--- a/app/views/pip-has-integration/v1/pip-case-details-updated.html
+++ b/app/views/pip-has-integration/v1/pip-case-details-updated.html
@@ -162,7 +162,7 @@
           Special rules end of life
         </dt>
         <dd class="govuk-summary-list__value">
-          No
+          {{ data["important-special-rules"] }}
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/important-end-of-life">

--- a/app/views/pip-has-integration/v1/pip-case-details.html
+++ b/app/views/pip-has-integration/v1/pip-case-details.html
@@ -122,6 +122,7 @@
         </dt>
         <dd class="govuk-summary-list__value">
           No
+          <!-- {{ data["important-special-rules"] }} -->
         </dd>
         <dd class="govuk-summary-list__actions">
           <a class="govuk-link" href="change-singular/important-end-of-life">


### PR DESCRIPTION
- Worked with Colin to display the confirmed SREL radio selection on the 'PIP case details updated' page. It wasn't parsing the data previously, but it should do now.